### PR TITLE
Fix ansible error: with_dict expects a dict

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,5 @@
     owner: root
     group: root
     mode: 0644
-  with_dict: logrotated_logrotate_d_files
+  with_dict: "{{ logrotated_logrotate_d_files }}"
   tags: [configuration, logrotated, logrotated-configuration, logrotated-configuration-logrotate-d]


### PR DESCRIPTION
This error happens with Ansible 2.2. Looks like they got more strict about the yaml syntax for loops.

FYI @dwcramer 